### PR TITLE
fix: 🐛 trigger github action on chrome browser

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,4 +11,4 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v4
         with:
-          start: npx cypress run 
+          browser: chrome


### PR DESCRIPTION
Added Chrome browser to trigger automated test.